### PR TITLE
🔨 Refactor - 상태 관리 세분화

### DIFF
--- a/lib/presentation/home/provider/home_provider.dart
+++ b/lib/presentation/home/provider/home_provider.dart
@@ -26,8 +26,9 @@ class HomeNotifier extends AutoDisposeNotifier<HomeState> {
   @override
   HomeState build() {
     _photoRepository = ref.watch(photoRepositoryProvider);
-
-    Future.microtask(_initLocationTracking);
+    if (_positionSubscription == null) {
+      Future.microtask(_initLocationTracking);
+    }
 
     ref.onDispose(() {
       _positionSubscription?.cancel();

--- a/lib/presentation/home/provider/home_provider.dart
+++ b/lib/presentation/home/provider/home_provider.dart
@@ -8,11 +8,13 @@ import '../../../data/repository/photo_repository.dart';
 import '../../../data/service_providers.dart';
 import 'home_contract.dart';
 
-final homeStateProvider = NotifierProvider.autoDispose<HomeNotifier, HomeState>(() => HomeNotifier());
+final homeStateProvider = NotifierProvider.autoDispose<HomeNotifier, HomeState>(
+  () => HomeNotifier(),
+);
 final homeEffectProvider = StateProvider.autoDispose<HomeEffect?>((ref) => null);
 
 class HomeNotifier extends AutoDisposeNotifier<HomeState> {
-  late final PhotoRepository _photoRepository;
+  late PhotoRepository _photoRepository;
   StreamSubscription<Position>? _positionSubscription;
 
   Timer? _throttleTimer;
@@ -25,7 +27,7 @@ class HomeNotifier extends AutoDisposeNotifier<HomeState> {
   HomeState build() {
     _photoRepository = ref.watch(photoRepositoryProvider);
 
-    _initLocationTracking();
+    Future.microtask(_initLocationTracking);
 
     ref.onDispose(() {
       _positionSubscription?.cancel();

--- a/lib/presentation/home/view/home_page.dart
+++ b/lib/presentation/home/view/home_page.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -37,16 +35,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(homeStateProvider);
+    ref.listen<List<PhotoData>>(
+      homeStateProvider.select((state) => state.photos),
+      (previous, next) {
+        _renderPhotoMarkers(next);
+      },
+    );
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _renderPhotoMarkers(state.photos);
-      if (state.userLatitude != null && state.userLongitude != null) {
-        _updateMyLocationMarker(state.userLatitude!, state.userLongitude!);
-      } else {
-        log('No initial location data available');
-      }
-    });
+    ref.listen<({double? latitude, double? longitude})>(
+      homeStateProvider.select(
+        (state) => (latitude: state.userLatitude, longitude: state.userLongitude),
+      ),
+      (previous, next) {
+        final hasPosition = next.latitude != null && next.longitude != null;
+        if (!hasPosition) return;
+
+        _updateMyLocationMarker(next.latitude!, next.longitude!);
+      },
+    );
 
     ref.listen<HomeEffect?>(homeEffectProvider, (previous, next) {
       if (next == null) return;
@@ -108,6 +114,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ),
       onMapReady: (controller) async {
         _mapController = controller;
+        _renderedPhotoIds.clear();
+
+        final currentState = ref.read(homeStateProvider);
+        _renderPhotoMarkers(currentState.photos);
+
+        final latitude = currentState.userLatitude;
+        final longitude = currentState.userLongitude;
+        if (latitude != null && longitude != null) {
+          await _updateMyLocationMarker(latitude, longitude);
+        }
       },
       onCameraIdle: () {
         final camera = _mapController!.nowCameraPosition;
@@ -166,6 +182,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   void _renderPhotoMarkers(List<PhotoData> photos) {
+    if (_mapController == null) return;
+
     for (final photo in photos) {
       final markerId = 'photo_${photo.id}';
       if (_renderedPhotoIds.contains(markerId)) continue;

--- a/lib/presentation/login/view/login_page.dart
+++ b/lib/presentation/login/view/login_page.dart
@@ -12,7 +12,9 @@ class LoginPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(loginStateProvider);
+    final isLoading = ref.watch(
+      loginStateProvider.select((state) => state.isLoading),
+    );
 
     ref.listen<LoginEffect?>(loginEffectProvider, (previous, next) {
       if (next == null) return;
@@ -35,49 +37,55 @@ class LoginPage extends ConsumerWidget {
       backgroundColor: PicpleColors.white,
       body: SafeArea(
         child: Center(
-          child: state.isLoading
-            ? const Center(child: CircularProgressIndicator())
-            : Column(
-                children: [
-                  const SizedBox(height: 100),
-                  Image.asset(
-                    'assets/icons/ic_picple.png',
-                    width: 300,
-                    height: 200,
-                  ),
-                  const Expanded(child: SizedBox()),
-                  state.isLoading
-                      ? const CircularProgressIndicator()
-                      : LoginButtons(
+          child: Column(
+            children: [
+              const SizedBox(height: 100),
+              Image.asset(
+                'assets/icons/ic_picple.png',
+                width: 300,
+                height: 200,
+              ),
+              const Expanded(child: SizedBox()),
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: isLoading
+                    ? const SizedBox(
+                        key: ValueKey('login_loading'),
+                        height: 48,
+                        child: Center(child: CircularProgressIndicator()),
+                      )
+                    : LoginButtons(
+                        key: const ValueKey('login_buttons'),
                         onPressed: () {
                           ref
                               .read(loginStateProvider.notifier)
                               .loginWithKakao();
                         },
                       ),
-                  const SizedBox(height: 20),
-                  RichText(
-                    text: const TextSpan(
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: Color(0xFF808080),
-                      ),
-                      children: [
-                        TextSpan(text: '첫 로그인 시, '),
-                        TextSpan(
-                          text: '서비스 이용약관',
-                          style: TextStyle(
-                            decoration: TextDecoration.underline,
-                            color: PicpleColors.gray5,
-                          ),
-                        ),
-                        TextSpan(text: '에 동의한 것으로 간주합니다.'),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                ],
               ),
+              const SizedBox(height: 20),
+              RichText(
+                text: const TextSpan(
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Color(0xFF808080),
+                  ),
+                  children: [
+                    TextSpan(text: '첫 로그인 시, '),
+                    TextSpan(
+                      text: '서비스 이용약관',
+                      style: TextStyle(
+                        decoration: TextDecoration.underline,
+                        color: PicpleColors.gray5,
+                      ),
+                    ),
+                    TextSpan(text: '에 동의한 것으로 간주합니다.'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/profile/provider/profile_contract.dart
+++ b/lib/presentation/profile/provider/profile_contract.dart
@@ -1,14 +1,16 @@
 import 'package:picple/data/model/response/my_photos_response.dart';
 
 class ProfileState {
-  final bool isLoading;
+  final bool isProfileLoading;
+  final bool isPhotosLoading;
   final String? profileImage;
   final String? nickname;
   final List<SimplePhotoData> myLikedPhotos;
   final List<SimplePhotoData> myPhotos;
 
   ProfileState({
-    this.isLoading = false,
+    this.isProfileLoading = false,
+    this.isPhotosLoading = false,
     this.profileImage,
     this.nickname,
     this.myLikedPhotos = const [],
@@ -16,20 +18,24 @@ class ProfileState {
   });
 
   ProfileState copyWith({
-    bool? isLoading,
+    bool? isProfileLoading,
+    bool? isPhotosLoading,
     String? profileImage,
     String? nickname,
     List<SimplePhotoData>? myLikedPhotos,
     List<SimplePhotoData>? myPhotos,
   }) {
     return ProfileState(
-      isLoading: isLoading ?? this.isLoading,
+      isProfileLoading: isProfileLoading ?? this.isProfileLoading,
+      isPhotosLoading: isPhotosLoading ?? this.isPhotosLoading,
       profileImage: profileImage ?? this.profileImage,
       nickname: nickname ?? this.nickname,
       myLikedPhotos: myLikedPhotos ?? this.myLikedPhotos,
       myPhotos: myPhotos ?? this.myPhotos,
     );
   }
+
+  bool get isLoading => isProfileLoading || isPhotosLoading;
 }
 
 abstract class ProfileEffect {}

--- a/lib/presentation/profile/provider/profile_notifier.dart
+++ b/lib/presentation/profile/provider/profile_notifier.dart
@@ -18,12 +18,10 @@ class ProfileNotifier extends AutoDisposeNotifier<ProfileState> {
   }
 
   Future<void> _initialize() async {
-    state = state.copyWith(isLoading: true);
     await Future.wait([
       _fetchProfile(),
       _fetchPhotos(),
     ]);
-    state = state.copyWith(isLoading: false);
   }
 
   void refreshState() {
@@ -31,7 +29,7 @@ class ProfileNotifier extends AutoDisposeNotifier<ProfileState> {
   }
 
   Future<void> _fetchPhotos() async {
-    state = state.copyWith(isLoading: true);
+    state = state.copyWith(isPhotosLoading: true);
 
     try {
       final myLikedPhotosResponse = await _profileRepository.getMyLikedPhotos();
@@ -55,18 +53,17 @@ class ProfileNotifier extends AutoDisposeNotifier<ProfileState> {
     } catch (e) {
       showToast("오류 발생: $e");
     } finally {
-      state = state.copyWith(isLoading: false);
+      state = state.copyWith(isPhotosLoading: false);
     }
   }
 
   Future<void> _fetchProfile() async {
-    state = state.copyWith(isLoading: true);
+    state = state.copyWith(isProfileLoading: true);
 
     try {
       final response = await _profileRepository.getProfile();
       if (response.isSuccess) {
         state = state.copyWith(
-          isLoading: false,
           profileImage: response.data?.profilePath,
           nickname: response.data?.username,
         );
@@ -76,7 +73,7 @@ class ProfileNotifier extends AutoDisposeNotifier<ProfileState> {
     } catch (e) {
       showToast("오류 발생: $e");
     } finally {
-      state = state.copyWith(isLoading: false);
+      state = state.copyWith(isProfileLoading: false);
     }
   }
 

--- a/lib/presentation/profile/view/profile_page.dart
+++ b/lib/presentation/profile/view/profile_page.dart
@@ -40,7 +40,9 @@ class _ProfilePageState extends ConsumerState<ProfilePage>
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(profileStateProvider);
+    final isLoading = ref.watch(
+      profileStateProvider.select((state) => state.isLoading),
+    );
 
     ref.listen<ProfileEffect?>(profileEffectProvider, (previous, next) {
       if (next == null) return;
@@ -78,17 +80,36 @@ class _ProfilePageState extends ConsumerState<ProfilePage>
           ),
         ],
       ),
-      body: state.isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : _buildProfileContent(state),
+      body: Stack(
+        children: [
+          _buildProfileContent(ref),
+          if (isLoading)
+            const Positioned.fill(
+              child: ColoredBox(
+                color: Colors.transparent,
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ),
+        ],
+      ),
       backgroundColor: PicpleColors.white,
     );
   }
 
-  Widget _buildProfileContent(ProfileState state) {
-    final selectedPhotos = _tabController.index == 0
-        ? state.myPhotos
-        : state.myLikedPhotos;
+  Widget _buildProfileContent(WidgetRef ref) {
+    final profileInfo = ref.watch(
+      profileStateProvider.select(
+        (state) => (image: state.profileImage, nickname: state.nickname),
+      ),
+    );
+    final myPhotos = ref.watch(
+      profileStateProvider.select((state) => state.myPhotos),
+    );
+    final likedPhotos = ref.watch(
+      profileStateProvider.select((state) => state.myLikedPhotos),
+    );
+
+    final selectedPhotos = _tabController.index == 0 ? myPhotos : likedPhotos;
 
     return RefreshIndicator(
       onRefresh: () async {
@@ -103,7 +124,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage>
               child: CachedNetworkImage(
                 width: 100,
                 height: 100,
-                imageUrl: state.profileImage ?? '',
+                imageUrl: profileInfo.image ?? '',
                 placeholder: (context, url) =>
                     Image.asset('assets/images/img_profile_placeholder.png'),
                 errorWidget: (context, url, error) =>
@@ -113,7 +134,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage>
             ),
             const SizedBox(height: 12),
             Text(
-              state.nickname ?? '닉네임 없음',
+              profileInfo.nickname ?? '닉네임 없음',
               style: PicpleTypography.title2,
             ),
             const SizedBox(height: 24),

--- a/lib/presentation/profile_edit/provider/profile_edit_contract.dart
+++ b/lib/presentation/profile_edit/provider/profile_edit_contract.dart
@@ -2,21 +2,30 @@ class ProfileEditState {
   final String nickname;
   final String? profileImageUrl;
   final String? imagePath;
-  final bool isLoading;
+  final bool isFetching;
+  final bool isSaving;
 
   ProfileEditState({
     this.nickname = '',
     this.profileImageUrl,
     this.imagePath,
-    this.isLoading = false,
+    this.isFetching = false,
+    this.isSaving = false,
   });
 
-  ProfileEditState copyWith({String? nickname, String? profileImageUrl, bool? isLoading, String? imagePath}) {
+  ProfileEditState copyWith({
+    String? nickname,
+    String? profileImageUrl,
+    bool? isFetching,
+    bool? isSaving,
+    String? imagePath,
+  }) {
     return ProfileEditState(
       nickname: nickname ?? this.nickname,
       profileImageUrl: profileImageUrl ?? this.profileImageUrl,
       imagePath: imagePath ?? this.imagePath,
-      isLoading: isLoading ?? this.isLoading,
+      isFetching: isFetching ?? this.isFetching,
+      isSaving: isSaving ?? this.isSaving,
     );
   }
 }

--- a/lib/presentation/profile_edit/provider/profile_edit_notifier.dart
+++ b/lib/presentation/profile_edit/provider/profile_edit_notifier.dart
@@ -20,13 +20,12 @@ class ProfileEditNotifier extends AutoDisposeNotifier<ProfileEditState> {
   }
 
   Future<void> _fetchProfile() async {
-    state = state.copyWith(isLoading: true);
+    state = state.copyWith(isFetching: true);
 
     try {
       final response = await _profileRepository.getProfile();
       if (response.isSuccess) {
         state = state.copyWith(
-          isLoading: false,
           profileImageUrl: response.data?.profilePath,
           nickname: response.data?.username,
         );
@@ -36,7 +35,7 @@ class ProfileEditNotifier extends AutoDisposeNotifier<ProfileEditState> {
     } catch (e) {
       _showToast("오류 발생: $e");
     } finally {
-      state = state.copyWith(isLoading: false);
+      state = state.copyWith(isFetching: false);
     }
   }
 
@@ -58,14 +57,14 @@ class ProfileEditNotifier extends AutoDisposeNotifier<ProfileEditState> {
 
     if (pickedFile != null) {
       final filePath = pickedFile.path;
-      ref.read(profileEditStateProvider.notifier).setImagePath(filePath);
+      setImagePath(filePath);
     } else {
       _showToast("이미지를 선택하지 않았습니다.");
     }
   }
 
   Future<void> saveChanges() async {
-    state = state.copyWith(isLoading: true);
+    state = state.copyWith(isSaving: true);
     try {
       final response = await _profileRepository.updateProfile(state.nickname, state.imagePath);
       if (response.isSuccess) {
@@ -79,7 +78,7 @@ class ProfileEditNotifier extends AutoDisposeNotifier<ProfileEditState> {
     } catch (e) {
       _showToast("저장 실패: $e");
     } finally {
-      state = state.copyWith(isLoading: false);
+      state = state.copyWith(isSaving: false);
     }
   }
 

--- a/lib/presentation/profile_edit/view/profile_edit_page.dart
+++ b/lib/presentation/profile_edit/view/profile_edit_page.dart
@@ -25,11 +25,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
     super.initState();
     final nickname = ref.read(profileEditStateProvider).nickname;
     _controller = TextEditingController(text: nickname);
-    _controller.addListener(() {
-      if (_controller.text != ref.read(profileEditStateProvider).nickname) {
-        ref.read(profileEditStateProvider.notifier).setNickname(_controller.text);
-      }
-    });
+    _controller.addListener(_handleNicknameChange);
   }
 
   @override
@@ -38,14 +34,41 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
     super.dispose();
   }
 
+  void _handleNicknameChange() {
+    final currentNickname = ref.read(profileEditStateProvider).nickname;
+    if (_controller.text == currentNickname) return;
+
+    ref.read(profileEditStateProvider.notifier).setNickname(_controller.text);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(profileEditStateProvider);
+    ref.listen<String>(
+      profileEditStateProvider.select((state) => state.nickname),
+      (previous, next) {
+        if (_controller.text == next) return;
+        _controller.value = TextEditingValue(
+          text: next,
+          selection: TextSelection.collapsed(offset: next.length),
+        );
+      },
+    );
 
-    if (_controller.text != state.nickname) {
-      _controller.text = state.nickname;
-      _controller.selection = TextSelection.fromPosition(TextPosition(offset: _controller.text.length));
-    }
+    final isFetching = ref.watch(
+      profileEditStateProvider.select((state) => state.isFetching),
+    );
+    final isSaving = ref.watch(
+      profileEditStateProvider.select((state) => state.isSaving),
+    );
+    final nickname = ref.watch(
+      profileEditStateProvider.select((state) => state.nickname),
+    );
+    final profileImageUrl = ref.watch(
+      profileEditStateProvider.select((state) => state.profileImageUrl),
+    );
+    final imagePath = ref.watch(
+      profileEditStateProvider.select((state) => state.imagePath),
+    );
 
     ref.listen<ProfileEditEffect?>(profileEditEffectProvider, (previous, next) {
       if (next == null) return;
@@ -76,7 +99,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
       ),
       backgroundColor: Colors.white,
       body: SafeArea(
-        child: state.isLoading
+        child: isFetching
                 ? const Center(child: CircularProgressIndicator())
                 : SingleChildScrollView(
                   padding: const EdgeInsets.only(bottom: 32), // 키보드에 가려지지 않게
@@ -88,11 +111,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
                         children: [
                           CircleAvatar(
                             radius: 125,
-                            backgroundImage: state.imagePath != null ?
-                            FileImage(File(state.imagePath!)) :
-                            state.profileImageUrl != null ?
-                            NetworkImage(state.profileImageUrl!) :
-                            const AssetImage('assets/images/img_profile_placeholder.png'),
+                            backgroundImage: _buildAvatarImage(imagePath, profileImageUrl),
                             backgroundColor: Colors.grey[200],
                           ),
                           Positioned(
@@ -139,7 +158,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
                             color: PicpleColors.gray3,
                             fontSize: 18,
                           ),
-                          enabled: !state.isLoading,
+                          enabled: !isSaving,
                           textColor: Colors.black,
                           borderColor: PicpleColors.gray2,
                           focusedBorderColor: PicpleColors.primary1,
@@ -147,7 +166,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
                           borderRadius: 12,
                           borderWidth: 1.0,
                           suffixIconAsset:
-                              state.nickname.isNotEmpty
+                              nickname.isNotEmpty
                                   ? 'assets/icons/ic_close.svg'
                                   : null,
                           onSuffixIconPressed:
@@ -179,7 +198,7 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
                 ),
               ),
               onPressed:
-                  state.isLoading
+                  isSaving
                       ? null
                       : () => ref.read(profileEditStateProvider.notifier)
                               .saveChanges(),
@@ -194,5 +213,17 @@ class _ProfileEditPageState extends ConsumerState<ProfileEditPage> {
         ),
       ),
     );
+  }
+
+  ImageProvider _buildAvatarImage(String? imagePath, String? profileImageUrl) {
+    if (imagePath != null && imagePath.isNotEmpty) {
+      return FileImage(File(imagePath));
+    }
+
+    if (profileImageUrl != null && profileImageUrl.isNotEmpty) {
+      return NetworkImage(profileImageUrl);
+    }
+
+    return const AssetImage('assets/images/img_profile_placeholder.png');
   }
 }

--- a/lib/presentation/setting/provider/setting_contract.dart
+++ b/lib/presentation/setting/provider/setting_contract.dart
@@ -1,11 +1,11 @@
 class SettingState {
-  final bool isLoading;
+  final bool isProcessing;
 
-  SettingState({this.isLoading = false});
+  SettingState({this.isProcessing = false});
 
-  SettingState copyWith({bool? isLoading}) {
+  SettingState copyWith({bool? isProcessing}) {
     return SettingState(
-      isLoading: isLoading ?? this.isLoading,
+      isProcessing: isProcessing ?? this.isProcessing,
     );
   }
 }

--- a/lib/presentation/setting/provider/setting_notifier.dart
+++ b/lib/presentation/setting/provider/setting_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:picple/data/repository/auth_repository.dart';
@@ -25,18 +27,45 @@ class SettingNotifier extends AutoDisposeNotifier<SettingState> {
     ref.read(settingEffectProvider.notifier).state = NavigateTo(route);
   }
 
-  void logout() async {
-    _authRepository.logout();
-    await UserApi.instance.unlink();
-    navigateBackToLogin();
-    _showToast("로그아웃되었습니다.");
+  Future<void> logout() async {
+    await _runAsyncAction(
+      action: () async {
+        _authRepository.logout();
+        await UserApi.instance.unlink();
+      },
+      onSuccess: () {
+        navigateBackToLogin();
+        _showToast("로그아웃되었습니다.");
+      },
+    );
   }
 
-  void withdraw() async {
-    _authRepository.withdrawal();
-    await UserApi.instance.unlink();
-    navigateBackToLogin();
-    _showToast("탈퇴가 완료되었습니다.");
+  Future<void> withdraw() async {
+    await _runAsyncAction(
+      action: () async {
+        _authRepository.withdrawal();
+        await UserApi.instance.unlink();
+      },
+      onSuccess: () {
+        navigateBackToLogin();
+        _showToast("탈퇴가 완료되었습니다.");
+      },
+    );
+  }
+
+  Future<void> _runAsyncAction({
+    required Future<void> Function() action,
+    required VoidCallback onSuccess,
+  }) async {
+    state = state.copyWith(isProcessing: true);
+    try {
+      await action();
+      onSuccess();
+    } catch (e) {
+      _showToast("오류가 발생했습니다: $e");
+    } finally {
+      state = state.copyWith(isProcessing: false);
+    }
   }
 
   void _showToast(String message) {

--- a/lib/presentation/setting/provider/setting_notifier.dart
+++ b/lib/presentation/setting/provider/setting_notifier.dart
@@ -30,7 +30,7 @@ class SettingNotifier extends AutoDisposeNotifier<SettingState> {
   Future<void> logout() async {
     await _runAsyncAction(
       action: () async {
-        _authRepository.logout();
+        await _authRepository.logout();
         await UserApi.instance.unlink();
       },
       onSuccess: () {
@@ -43,7 +43,7 @@ class SettingNotifier extends AutoDisposeNotifier<SettingState> {
   Future<void> withdraw() async {
     await _runAsyncAction(
       action: () async {
-        _authRepository.withdrawal();
+        await _authRepository.withdrawal();
         await UserApi.instance.unlink();
       },
       onSuccess: () {

--- a/lib/presentation/setting/view/setting_page.dart
+++ b/lib/presentation/setting/view/setting_page.dart
@@ -14,7 +14,10 @@ class SettingPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final notifier = ref.watch(settingStateProvider.notifier);
+    final isProcessing = ref.watch(
+      settingStateProvider.select((state) => state.isProcessing),
+    );
+    final notifier = ref.read(settingStateProvider.notifier);
 
     ref.listen<SettingEffect?>(settingEffectProvider, (previous, next) {
       if (next == null) return;
@@ -50,70 +53,83 @@ class SettingPage extends ConsumerWidget {
         ),
         centerTitle: true,
       ),
-      body: Container(
-        color: PicpleColors.white,
-        width: double.infinity,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _SettingItem(
-              icon: Icons.person_outline,
-              label: '프로필 수정',
-              onTap: () => notifier.navigateTo("${Routes.profile.path}/${Routes.profileEdit.path}"),
-            ),
-            _SettingItem(
-              icon: Icons.description_outlined,
-              label: '서비스 이용약관',
-              onTap: () {},
-            ),
-            _SettingItem(
-              icon: Icons.location_on_outlined,
-              label: '위치정보 이용약관',
-              onTap: () {},
-            ),
-            _SettingItem(
-              icon: Icons.assignment_outlined,
-              label: '개인정보 처리방침',
-              onTap: () {},
-            ),
-            _SettingItem(
-              icon: Icons.logout,
-              label: '로그아웃',
-              onTap: () => notifier.logout(),
-            ),
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-              child: Row(
-                children: [
-                  Icon(Icons.info_outline, color: PicpleColors.gray5, size: 24),
-                  SizedBox(width: 16),
-                  Text(
-                    '버전 정보',
-                    style: PicpleTypography.body1,
+      body: Stack(
+        children: [
+          Container(
+            color: PicpleColors.white,
+            width: double.infinity,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _SettingItem(
+                  icon: Icons.person_outline,
+                  label: '프로필 수정',
+                  onTap: () => notifier.navigateTo("${Routes.profile.path}/${Routes.profileEdit.path}"),
+                ),
+                _SettingItem(
+                  icon: Icons.description_outlined,
+                  label: '서비스 이용약관',
+                  onTap: () {},
+                ),
+                _SettingItem(
+                  icon: Icons.location_on_outlined,
+                  label: '위치정보 이용약관',
+                  onTap: () {},
+                ),
+                _SettingItem(
+                  icon: Icons.assignment_outlined,
+                  label: '개인정보 처리방침',
+                  onTap: () {},
+                ),
+                _SettingItem(
+                  icon: Icons.logout,
+                  label: '로그아웃',
+                  onTap: isProcessing ? null : notifier.logout,
+                ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.info_outline, color: PicpleColors.gray5, size: 24),
+                      SizedBox(width: 16),
+                      Text(
+                        '버전 정보',
+                        style: PicpleTypography.body1,
+                      ),
+                      Spacer(),
+                      Text(
+                        'v1.0.0',
+                        style: PicpleTypography.body1,
+                      ),
+                    ],
                   ),
-                  Spacer(),
-                  Text(
-                    'v1.0.0',
-                    style: PicpleTypography.body1,
+                ),
+                Center(
+                  child: TextButton(
+                    onPressed: isProcessing ? null : notifier.withdraw,
+                    child: const Text(
+                      '탈퇴하기',
+                      style: TextStyle(
+                        color: PicpleColors.gray5,
+                        fontSize: 14,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-            Center(
-              child: TextButton(
-                onPressed: () => notifier.withdraw(),
-                child: const Text(
-                  '탈퇴하기',
-                  style: TextStyle(
-                    color: PicpleColors.gray5,
-                    fontSize: 14,
-                    decoration: TextDecoration.underline,
-                  ),
+          ),
+          if (isProcessing)
+            const Positioned.fill(
+              child: ColoredBox(
+                color: Colors.black26,
+                child: Center(
+                  child: CircularProgressIndicator(),
                 ),
               ),
             ),
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/presentation/setting/view/setting_page.dart
+++ b/lib/presentation/setting/view/setting_page.dart
@@ -84,7 +84,11 @@ class SettingPage extends ConsumerWidget {
                 _SettingItem(
                   icon: Icons.logout,
                   label: '로그아웃',
-                  onTap: isProcessing ? null : notifier.logout,
+                  onTap: isProcessing
+                      ? null
+                      : () async {
+                          await notifier.logout();
+                        },
                 ),
                 const Padding(
                   padding: EdgeInsets.symmetric(horizontal: 24, vertical: 16),
@@ -106,7 +110,11 @@ class SettingPage extends ConsumerWidget {
                 ),
                 Center(
                   child: TextButton(
-                    onPressed: isProcessing ? null : notifier.withdraw,
+                    onPressed: isProcessing
+                        ? null
+                        : () async {
+                          await notifier.withdraw();
+                        },
                     child: const Text(
                       '탈퇴하기',
                       style: TextStyle(

--- a/lib/presentation/splash/provider/splash_notifier.dart
+++ b/lib/presentation/splash/provider/splash_notifier.dart
@@ -14,7 +14,6 @@ class SplashNotifier extends AutoDisposeNotifier<SplashState> {
   @override
   SplashState build() {
     _storageApi = ref.watch(storageApiProvider);
-    Future.delayed(const Duration(seconds: 1), checkLogin);
     return SplashState();
   }
 

--- a/lib/presentation/splash/provider/splash_notifier.dart
+++ b/lib/presentation/splash/provider/splash_notifier.dart
@@ -14,6 +14,7 @@ class SplashNotifier extends AutoDisposeNotifier<SplashState> {
   @override
   SplashState build() {
     _storageApi = ref.watch(storageApiProvider);
+    Future.delayed(const Duration(seconds: 1), checkLogin);
     return SplashState();
   }
 

--- a/lib/presentation/splash/view/splash_page.dart
+++ b/lib/presentation/splash/view/splash_page.dart
@@ -6,11 +6,24 @@ import '../../theme/picple_colors.dart';
 import '../provider/splash_contract.dart';
 import '../provider/splash_notifier.dart';
 
-class SplashPage extends ConsumerWidget {
+class SplashPage extends ConsumerStatefulWidget {
   const SplashPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends ConsumerState<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      ref.read(splashStateProvider.notifier).checkLogin();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     ref.listen<SplashEffect?>(splashEffectProvider, (previous, next) {
       if (next == null) return;
 

--- a/lib/presentation/splash/view/splash_page.dart
+++ b/lib/presentation/splash/view/splash_page.dart
@@ -11,10 +11,6 @@ class SplashPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(splashStateProvider.notifier).checkLogin();
-    });
-
     ref.listen<SplashEffect?>(splashEffectProvider, (previous, next) {
       if (next == null) return;
 

--- a/lib/presentation/upload/provider/upload_contract.dart
+++ b/lib/presentation/upload/provider/upload_contract.dart
@@ -3,20 +3,20 @@ import 'dart:io';
 import '../../../data/model/response/nearby_photos_response.dart';
 
 class UploadState {
-  final bool isLoading;
+  final bool isUploading;
   final File? photo;
 
   UploadState({
-    this.isLoading = false,
+    this.isUploading = false,
     this.photo,
   });
 
   UploadState copyWith({
-    bool? isLoading,
+    bool? isUploading,
     File? photo,
   }) {
     return UploadState(
-      isLoading: isLoading ?? this.isLoading,
+      isUploading: isUploading ?? this.isUploading,
       photo: photo ?? this.photo,
     );
   }

--- a/lib/presentation/upload/provider/upload_provider.dart
+++ b/lib/presentation/upload/provider/upload_provider.dart
@@ -37,7 +37,7 @@ class UploadNotifier extends AutoDisposeNotifier<UploadState> {
       return;
     }
 
-    state = state.copyWith(isLoading: true);
+    state = state.copyWith(isUploading: true);
 
     try {
       final compressedFile = await resizeAndCompressImageFile(file: originalFile);
@@ -79,7 +79,7 @@ class UploadNotifier extends AutoDisposeNotifier<UploadState> {
     } catch (e) {
       _showToast("오류 발생: $e");
     } finally {
-      state = state.copyWith(isLoading: false);
+      state = state.copyWith(isUploading: false);
     }
   }
 

--- a/lib/presentation/upload/view/upload_page.dart
+++ b/lib/presentation/upload/view/upload_page.dart
@@ -36,15 +36,6 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
   final _titleController = TextEditingController();
   final _descriptionController = TextEditingController();
 
-  bool get _isFormValid {
-    final state = ref.watch(uploadStateProvider);
-
-    return state.photo != null &&
-        state.photo!.existsSync() &&
-        _titleController.text.trim().isNotEmpty &&
-        _descriptionController.text.trim().isNotEmpty;
-  }
-
   Future<void> _takePhoto() async {
     final pickedFile = await _picker.pickImage(source: ImageSource.camera);
 
@@ -67,7 +58,6 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
       await Future.delayed(const Duration(milliseconds: 300)); // 안전한 딜레이
       if (!mounted) return;
       ref.read(uploadStateProvider.notifier).setPhoto(File(pickedFile.path));
-      setState(() {});
     }
   }
 
@@ -97,7 +87,14 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(uploadStateProvider);
+    final photoFile = ref.watch(
+      uploadStateProvider.select((state) => state.photo),
+    );
+    final isUploading = ref.watch(
+      uploadStateProvider.select((state) => state.isUploading),
+    );
+    final hasPhoto = photoFile != null && photoFile.existsSync();
+    final isFormValid = _isFormValid(hasPhoto, isUploading);
     ref.listen<UploadEffect?>(uploadEffectProvider, (previous, next) {
       if (next == null) return;
 
@@ -146,9 +143,9 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
                   // 사진 미리보기
                   AspectRatio(
                     aspectRatio: 1.0,
-                    child: state.photo != null && state.photo!.existsSync()
+                    child: hasPhoto
                         ? Image.file(
-                          state.photo!,
+                          photoFile,
                           width: double.infinity,
                           height: double.infinity,
                           fit: BoxFit.cover,
@@ -203,7 +200,7 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
               ),
             ),
 
-            if (state.isLoading)
+            if (isUploading)
               const Positioned.fill(
                 child: ColoredBox(
                   color: Colors.black45,
@@ -218,8 +215,8 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
-          child: ElevatedButton(
-            onPressed: _isFormValid && !state.isLoading ? () async {
+            child: ElevatedButton(
+            onPressed: isFormValid ? () async {
               final title = _titleController.text.trim();
               final description = _descriptionController.text.trim();
 
@@ -232,9 +229,9 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
-            ),
-            child: Text(
-              '등록하기',
+              ),
+              child: Text(
+                '등록하기',
               style: PicpleTypography.body1SemiBold.copyWith(
                 color: PicpleColors.white,
               )
@@ -243,6 +240,14 @@ class _UploadScreenState extends ConsumerState<UploadScreen> {
         ),
       ),
     );
+  }
+
+  bool _isFormValid(bool hasPhoto, bool isUploading) {
+    if (isUploading) return false;
+
+    return hasPhoto &&
+        _titleController.text.trim().isNotEmpty &&
+        _descriptionController.text.trim().isNotEmpty;
   }
 
   Future<void> _handleUpload(BuildContext context, WidgetRef ref, String title, String description) async {


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #52 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Home: Notifier가 repository를 바인딩할 때만 위치 추적을 시작하고, 지도 위젯은 ref.listen으로 사진·위치 업데이트를 분리 감지해 불필요한 전체 리빌드를 제거했습니다.
- Login: AnimatedSwitcher와 select를 도입해 isLoading 변화 시 버튼 영역만 전환하도록 최적화했습니다.
- Profile / Profile Edit: 각각의 로딩 단계를 분리(isProfileLoading, isPhotosLoading, isFetching, isSaving)하고, 화면은 필요한 상태 조각만 구독하도록 select/ref.listen을 적용해 헤더·그리드·폼이 독립적으로 갱신됩니다.
- Upload: 상태를 isUploading과 photo로 나눠 미리보기·버튼·오버레이가 최소 구독으로 동작하게 했고, 폼 유효성 검사도 지역적으로 계산합니다.
- Setting: 로그아웃/탈퇴 동작을 공통 헬퍼로 감싸 isProcessing 플래그를 관리하며, 버튼 비활성화 + 전체 오버레이로 처리 중임을 표시합니다.
- Splash: Future.delayed를 통해 화면 렌더 후 1초 뒤에 checkLogin()이 실행되어, 위젯에서 post-frame 콜백 없이도 네비게이션 이벤트가 안정적으로 반영됩니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 페이지에 로그아웃/탈퇴 시 전체 화면 로딩 오버레이 추가
  * 로그인 화면에 로딩 상태 전환 애니메이션 개선
  * 지도: 초기 지도 준비 시 마커와 내 위치 표시가 안정적으로 초기화/렌더링되도록 개선

* **개선 사항**
  * 프로필 관련 로딩 상태를 세분화(isProfileLoading/isPhotosLoading)하여 UI에 개별 반영
  * 프로필 수정에서 가져오기/저장 상태 분리 및 관련 UI 개선
  * 업로드 상태 플래그(isUploading) 적용으로 폼 검증과 버튼 활성화 개선

* **버그 수정**
  * 위치 구독 및 타이머가 정상 해제되어 중복 구독/리소스 누수 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->